### PR TITLE
allow eni pass struct member

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -775,6 +775,30 @@ void NewExpression::replaceChild(Expression*, ASTPointer<Expression>)
 
 }
 
+bool MemberAccess::saveToENISection(ENIHandler& _handler, CompilerContext& _context) const 
+{ 
+	CompilerContext::LocationSetter locationSetter(_context, *this);
+	Declaration const* declaration = this->annotation().referencedDeclaration;
+	auto variable = dynamic_cast<VariableDeclaration const*>(declaration);
+	auto ide = std::dynamic_pointer_cast<Identifier>( m_expression );
+
+	_handler.appendIdentifier(annotation().type, *variable, static_cast<Expression const&>(*this));
+	if (!variable->isConstant()) {
+		/// variable is not a constant.
+		if (_context.isLocalVariable(ide->annotation().referencedDeclaration)) {
+			/// local variable
+		} else if (_context.isStateVariable(ide->annotation().referencedDeclaration)) {
+			/// state variable
+		} else {
+			solUnimplementedAssert(false, "Unsupported identifier type\n");
+		}
+	} else {
+		solUnimplementedAssert(false, "Should handler constant identifier\n");
+	}
+	_handler.setContext(&_context);
+	return true;
+};
+
 void MemberAccess::replaceChild(Expression *oldExp, ASTPointer<Expression> newExp)
 {
 	if(m_expression.get()==oldExp) m_expression = newExp;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1691,6 +1691,8 @@ public:
 	{
 		return std::make_shared<MemberAccess>(location(), m_expression->deepCopy(), m_memberName);
 	}
+
+	bool saveToENISection(ENIHandler&, CompilerContext&) const override;
 private:
 	ASTPointer<Expression> m_expression;
 	ASTPointer<ASTString> m_memberName;


### PR DESCRIPTION
### Description

This allow to use struct member for eni 

```sol
struct Data {
    string name;
    uint age;
}
Data memory data;
eni("do_something", data.name, data.age);  // Not allowed before this pr.
```

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
