### PR TITLE
Update debian/compat to version 13

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -106,7 +106,7 @@ cp /tmp/${packagename}_${debversion}.orig.tar.gz ../
 # Create debian package information
 
 mkdir debian
-echo 9 > debian/compat
+echo 13 > debian/compat
 cat <<EOF > debian/control
 Source: solc
 Section: science


### PR DESCRIPTION

Compat version 13 is currently the recommended one.

An important change introduced in 10 was change of default to target parallel builds

https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/debhelper.pod#compatibility-levels

<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
